### PR TITLE
Fragments and improved conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# hast-typescript-lib
+
+Types, conversions, utilities as well as certain extensions for the [Hypertext Abstract Syntax Tree](https://github.com/syntax-tree/hast).
+
+## Installation
+
+```
+yarn add @universitetsforlaget/hast
+```

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   preset: 'ts-jest',
+  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
   testEnvironment: 'node',
 };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "jest",
     "tdd": "jest --watch",
-    "build": "tsc"
+    "build": "rm -rf ./dist && tsc"
   },
   "devDependencies": {
     "@types/jest": "^24.0.11",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@types/jest": "^24.0.11",
     "@types/xmldom": "^0.1.29",
     "jest": "^24.5.0",
+    "react-html-attributes": "^1.4.3",
     "ts-jest": "^24.0.0",
     "typescript": "^3.3.4000",
     "xmldom": "^0.1.27"

--- a/package.json
+++ b/package.json
@@ -16,9 +16,11 @@
     "@types/jest": "^24.0.11",
     "@types/xmldom": "^0.1.29",
     "jest": "^24.5.0",
-    "react-html-attributes": "^1.4.3",
     "ts-jest": "^24.0.0",
     "typescript": "^3.3.4000",
     "xmldom": "^0.1.27"
+  },
+  "dependencies": {
+    "property-information": "^5.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@universitetsforlaget/hast",
-  "version": "0.2.1-SNAPSHOT",
+  "version": "0.3.0-SNAPSHOT",
   "description": "Hypertext Abstract Syntax Tree utilities",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,30 +1,103 @@
+import { HastProperties } from "./types";
+
 export type ContentType = 'text/html' | 'application/xml';
 
 export interface SerializationConfig {
   contentType: ContentType;
   serializeTagName: (name: string) => string | null;
-  serializeAttributeName: (name: string) => string | null;
+  serializeAttributeName: (tagName: string, attributeName: string) => string | null;
 };
 
 export interface DeserializationConfig {
   contentType: ContentType;
   deserializeTagName: (name: string) => string | null;
-  deserializeAttributeName: (name: string) => string | null;
+  deserializeAttribute: (
+    tagName: string,
+    name: string,
+    value: string | null
+  ) => HastProperties;
 };
 
-export const html5SerializationConfig = (): SerializationConfig => ({
+export interface HtmlAttributeMap {
+  toHtml: { [tagName: string]: { [ camelCased: string]: string }},
+  toHast: { [tagName: string]: { [ lowercased: string]: string }},
+};
+
+export const compileAttributeMap = (
+  reactHtmlAttributes: { [key: string]: string[] },
+): HtmlAttributeMap => {
+  return {
+    toHtml: Object.keys(reactHtmlAttributes).reduce((tags, key) => {
+      if (key === 'elements') return tags;
+      return {
+        ...tags,
+        [key]: reactHtmlAttributes[key].reduce((attrs, attribute) => ({
+          ...attrs,
+          [attribute]: attribute.toLowerCase(),
+        }), {})
+      };
+    }, {}),
+    toHast: Object.keys(reactHtmlAttributes).reduce((tags, key) => {
+      if (key === 'elements') return tags;
+      return {
+        ...tags,
+        [key]: reactHtmlAttributes[key].reduce((attrs, attribute) => ({
+          ...attrs,
+          [attribute.toLowerCase()]: attribute,
+        }), {}),
+      };
+    }, {}),
+  };
+}
+
+export const html5SerializationConfig = (
+  attributeMap: HtmlAttributeMap,
+): SerializationConfig => ({
   contentType: 'text/html',
   serializeTagName: name => name,
-  serializeAttributeName: name => name,
+  serializeAttributeName: (tagName, attributeName) => {
+    return attributeName;
+  }
 });
 
-export const html5DeserializationConfig = (): DeserializationConfig => ({
+export const html5DeserializationConfig = (
+  attributeMap: HtmlAttributeMap,
+): DeserializationConfig => ({
   contentType: 'text/html',
   deserializeTagName: name => name.toLowerCase(),
-  deserializeAttributeName: name => name,
+  deserializeAttribute: (tagName: string, name, value) => {
+    if (name === 'class') {
+      return {
+        className: (value || '').split(' ').filter(Boolean),
+      };
+    } else if (name === 'for') {
+      return {
+        htmlFor: value,
+      };
+    } else if (name.startsWith('data-') || name.startsWith('aria-')) {
+      // Just convert to lower case
+      return {
+        [name.toLowerCase()]: value,
+      };
+    } else {
+      // To camelCase
+      const normalizedName = name.replace(/-([a-z])/g, '').toLowerCase();
+
+      const propertyName =
+        (attributeMap.toHast[tagName] && attributeMap.toHast[tagName][normalizedName])
+        || attributeMap.toHast['*'][normalizedName]
+        || null;
+
+      return propertyName
+        ? { [propertyName]: value }
+        : {};
+    }
+  },
 });
 
-export const xmlSerializationConfig = (): SerializationConfig => ({
+export const xmlSerializationConfig = (
+
+): SerializationConfig => ({
   contentType: 'application/xml',
   serializeTagName: name => name,
   serializeAttributeName: name => name,
@@ -33,5 +106,5 @@ export const xmlSerializationConfig = (): SerializationConfig => ({
 export const xmlDeserializationConfig = (): DeserializationConfig => ({
   contentType: 'application/xml',
   deserializeTagName: name => name,
-  deserializeAttributeName: name => name,
+  deserializeAttribute: (tagName, name, value) => ({ [name]: value }),
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,11 @@ export interface HtmlAttributeMap {
   toHast: { [tagName: string]: { [ lowercased: string]: string }},
 };
 
+/**
+ * Compile html attribute map, that can mostly correctly convert between HTML and HAST attributes.
+ * Hast attribute names are compatible with attributes used by DOM js APIs (and React).
+ * @param reactHtmlAttributes The default export of npm module 'react-html-attributes'
+ */
 export const compileAttributeMap = (
   reactHtmlAttributes: { [key: string]: string[] },
 ): HtmlAttributeMap => {
@@ -107,9 +112,7 @@ export const html5DeserializationConfig = (
   },
 });
 
-export const xmlSerializationConfig = (
-
-): SerializationConfig => ({
+export const xmlSerializationConfig = (): SerializationConfig => ({
   serializeTagName: name => name,
   serializeAttribute: (tagName, name, value) => [name, `${value}`],
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,8 @@
-import { HastProperties } from "./types";
+import { HastNode, HastProperties } from "./types";
+import { isElement } from "./util";
 
 export interface SerializationConfig {
+  isFragment: (node: HastNode) => boolean;
   serializeTagName: (name: string) => string | null;
   serializeAttribute: (
     tagName: string,
@@ -58,6 +60,7 @@ export const compileAttributeMap = (
 export const html5SerializationConfig = (
   attributeMap: HtmlAttributeMap,
 ): SerializationConfig => ({
+  isFragment: node => isElement(node) && node.tagName === 'fragment',
   serializeTagName: name => name,
   serializeAttribute: (tagName, name, value) => {
     if (name === 'className') {
@@ -113,6 +116,7 @@ export const html5DeserializationConfig = (
 });
 
 export const xmlSerializationConfig = (): SerializationConfig => ({
+  isFragment: node => false,
   serializeTagName: name => name,
   serializeAttribute: (tagName, name, value) => [name, `${value}`],
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,19 +1,15 @@
 import { HastProperties } from "./types";
 
-export type ContentType = 'text/html' | 'application/xml';
-
 export interface SerializationConfig {
-  contentType: ContentType;
   serializeTagName: (name: string) => string | null;
   serializeAttribute: (
     tagName: string,
     name: string,
     value: any
-  ) => [string, string] | null;
+  ) => [string, string] | string | null;
 };
 
 export interface DeserializationConfig {
-  contentType: ContentType;
   deserializeTagName: (name: string) => string | null;
   deserializeAttribute: (
     tagName: string,
@@ -57,7 +53,6 @@ export const compileAttributeMap = (
 export const html5SerializationConfig = (
   attributeMap: HtmlAttributeMap,
 ): SerializationConfig => ({
-  contentType: 'text/html',
   serializeTagName: name => name,
   serializeAttribute: (tagName, name, value) => {
     if (name === 'className') {
@@ -65,7 +60,7 @@ export const html5SerializationConfig = (
     } else if (name === 'htmlFor') {
       return ['for', `${value}`];
     } else if (name.startsWith('data-') || name.startsWith('aria-')) {
-      return ['for', `${value}`];
+      return [name, `${value}`];
     } else {
       const serializedName =
         attributeMap.toHtml[tagName] && attributeMap.toHtml[tagName][name]
@@ -81,7 +76,6 @@ export const html5SerializationConfig = (
 export const html5DeserializationConfig = (
   attributeMap: HtmlAttributeMap,
 ): DeserializationConfig => ({
-  contentType: 'text/html',
   deserializeTagName: name => name.toLowerCase(),
   deserializeAttribute: (tagName: string, name, value) => {
     if (name === 'class') {
@@ -116,13 +110,11 @@ export const html5DeserializationConfig = (
 export const xmlSerializationConfig = (
 
 ): SerializationConfig => ({
-  contentType: 'application/xml',
   serializeTagName: name => name,
   serializeAttribute: (tagName, name, value) => [name, `${value}`],
 });
 
 export const xmlDeserializationConfig = (): DeserializationConfig => ({
-  contentType: 'application/xml',
   deserializeTagName: name => name,
   deserializeAttribute: (tagName, name, value) => ({ [name]: value }),
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,37 @@
+export type ContentType = 'text/html' | 'application/xml';
+
+export interface SerializationConfig {
+  contentType: ContentType;
+  serializeTagName: (name: string) => string | null;
+  serializeAttributeName: (name: string) => string | null;
+};
+
+export interface DeserializationConfig {
+  contentType: ContentType;
+  deserializeTagName: (name: string) => string | null;
+  deserializeAttributeName: (name: string) => string | null;
+};
+
+export const html5SerializationConfig = (): SerializationConfig => ({
+  contentType: 'text/html',
+  serializeTagName: name => name,
+  serializeAttributeName: name => name,
+});
+
+export const html5DeserializationConfig = (): DeserializationConfig => ({
+  contentType: 'text/html',
+  deserializeTagName: name => name.toLowerCase(),
+  deserializeAttributeName: name => name,
+});
+
+export const xmlSerializationConfig = (): SerializationConfig => ({
+  contentType: 'application/xml',
+  serializeTagName: name => name,
+  serializeAttributeName: name => name,
+});
+
+export const xmlDeserializationConfig = (): DeserializationConfig => ({
+  contentType: 'application/xml',
+  deserializeTagName: name => name,
+  deserializeAttributeName: name => name,
+});

--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -1,33 +1,36 @@
 import {
-  HastFragmentNode, ContentType,
+  HastNode,
+  HastTextNode,
+  HastFragmentNode,
+  ContentType,
 } from './types';
+import * as dom from './dom';
+import * as serialization from './serialization';
 import { compressFragmentNode } from './util';
-import { hastChildrenOfNode } from './dom';
-import { hastNodeToUtf8Markup } from './serialization';
 
-/** Convert plaintext string to hast fragment */
-export const stringToHastFragment = (text: string): HastFragmentNode => ({
-  type: 'element',
-  tagName: 'fragment',
-  children: [{
-    type: 'text',
-    value: text,
-  }]
+/** Convert plaintext string to hast text node */
+export const stringToHast = (text: string): HastTextNode => ({
+  type: 'text',
+  value: text,
 });
 
-/** Convert any dom Element to hast fragment */
-export const domElementToHastFragment = (
-  root: Node,
+/** Convert any dom node to hast, if possible */
+export const domNodeToHast = (
+  node: Node,
+  contentType: ContentType,
+): HastNode | null => dom.nodeToHast(node, contentType);
+
+/** Convert a dom node's content to a hast fragment */
+export const domNodeToHastFragment = (
+  node: Node,
   contentType: ContentType,
 ): HastFragmentNode => compressFragmentNode({
   type: 'element',
   tagName: 'fragment',
-  children: hastChildrenOfNode(root, contentType),
+  children: dom.nodeChildrenToHastArray(node, contentType),
 });
 
-/** Convert any hast fragment to "flattened" html5 (fragment node is stripped) */
-export const hastFragmentToFlattenedHtml5 = (fragment: HastFragmentNode): string => {
-  return fragment.children
-    ? fragment.children.map(hastNodeToUtf8Markup).join('')
-    : '';
+/** Convert hast to html5 string (fragment nodes will be stripped) */
+export const hastToHtml5 = (node: HastNode): string => {
+  return serialization.hastNodeToUtf8Markup(node);
 };

--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -1,33 +1,33 @@
 import {
-  HastBodyNode, ContentType,
+  HastFragmentNode, ContentType,
 } from './types';
-import { compressBodyNode } from './util';
+import { compressFragmentNode } from './util';
 import { hastChildrenOfNode } from './dom';
 import { hastNodeToUtf8Markup } from './serialization';
 
-/** Convert plaintext string to hast body */
-export const stringToHastBody = (text: string): HastBodyNode => ({
+/** Convert plaintext string to hast fragment */
+export const stringToHastFragment = (text: string): HastFragmentNode => ({
   type: 'element',
-  tagName: 'body',
+  tagName: 'fragment',
   children: [{
     type: 'text',
     value: text,
   }]
 });
 
-/** Convert any dom Element to hast body */
-export const domElementToHastBody = (
+/** Convert any dom Element to hast fragment */
+export const domElementToHastFragment = (
   root: Node,
   contentType: ContentType,
-): HastBodyNode => compressBodyNode({
+): HastFragmentNode => compressFragmentNode({
   type: 'element',
-  tagName: 'body',
+  tagName: 'fragment',
   children: hastChildrenOfNode(root, contentType),
 });
 
-/** Convert any hast body node to "flattened" html5 (body node is stripped) */
-export const hastBodyToFlattenedHtml5 = (body: HastBodyNode): string => {
-  return body.children
-    ? body.children.map(hastNodeToUtf8Markup).join('')
+/** Convert any hast fragment to "flattened" html5 (fragment node is stripped) */
+export const hastFragmentToFlattenedHtml5 = (fragment: HastFragmentNode): string => {
+  return fragment.children
+    ? fragment.children.map(hastNodeToUtf8Markup).join('')
     : '';
 };

--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -6,7 +6,7 @@ import {
 import * as dom from './dom';
 import * as serialization from './serialization';
 import { compressFragmentNode } from './util';
-import { DeserializationConfig } from './config';
+import { DeserializationConfig, SerializationConfig } from './config';
 
 /** Convert plaintext string to hast text node */
 export const stringToHast = (text: string): HastTextNode => ({
@@ -31,6 +31,9 @@ export const domNodeToHastFragment = (
 });
 
 /** Convert hast to html5 string (fragment nodes will be stripped) */
-export const hastToHtml5 = (node: HastNode): string => {
-  return serialization.hastNodeToUtf8Markup(node);
+export const hastToHtml5 = (
+  node: HastNode,
+  config: SerializationConfig,
+): string => {
+  return serialization.hastNodeToUtf8Markup(node, config);
 };

--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -20,7 +20,7 @@ export const domNodeToHast = (
   config: DeserializationConfig,
 ): HastNode | null => dom.nodeToHast(node, config);
 
-/** Convert a dom node's content to a hast fragment */
+/** Convert a dom node's content (i.e. children) to a hast fragment */
 export const domNodeToHastFragment = (
   node: Node,
   config: DeserializationConfig,

--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -14,6 +14,15 @@ export const stringToHast = (text: string): HastTextNode => ({
   value: text,
 });
 
+/** Create a fragment enclosing the given nodes */
+export const createFragment = (
+  ...nodes: HastNode[]
+): HastFragmentNode => compressFragmentNode({
+  type: 'element',
+  tagName: 'fragment',
+  children: nodes,
+});
+
 /** Convert any dom node to hast, if possible */
 export const domNodeToHast = (
   node: Node,
@@ -24,11 +33,9 @@ export const domNodeToHast = (
 export const domNodeToHastFragment = (
   node: Node,
   config: DeserializationConfig,
-): HastFragmentNode => compressFragmentNode({
-  type: 'element',
-  tagName: 'fragment',
-  children: dom.nodeChildrenToHastArray(node, config),
-});
+): HastFragmentNode => createFragment(
+  ...dom.nodeChildrenToHastArray(node, config),
+);
 
 /** Convert hast to html5 string (fragment nodes will be stripped) */
 export const hastToHtml5 = (

--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -2,11 +2,11 @@ import {
   HastNode,
   HastTextNode,
   HastFragmentNode,
-  ContentType,
 } from './types';
 import * as dom from './dom';
 import * as serialization from './serialization';
 import { compressFragmentNode } from './util';
+import { DeserializationConfig } from './config';
 
 /** Convert plaintext string to hast text node */
 export const stringToHast = (text: string): HastTextNode => ({
@@ -17,17 +17,17 @@ export const stringToHast = (text: string): HastTextNode => ({
 /** Convert any dom node to hast, if possible */
 export const domNodeToHast = (
   node: Node,
-  contentType: ContentType,
-): HastNode | null => dom.nodeToHast(node, contentType);
+  config: DeserializationConfig,
+): HastNode | null => dom.nodeToHast(node, config);
 
 /** Convert a dom node's content to a hast fragment */
 export const domNodeToHastFragment = (
   node: Node,
-  contentType: ContentType,
+  config: DeserializationConfig,
 ): HastFragmentNode => compressFragmentNode({
   type: 'element',
   tagName: 'fragment',
-  children: dom.nodeChildrenToHastArray(node, contentType),
+  children: dom.nodeChildrenToHastArray(node, config),
 });
 
 /** Convert hast to html5 string (fragment nodes will be stripped) */

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -50,9 +50,14 @@ export const nodeToHast = (
   node: Node,
   contentType: ContentType,
 ): HastNode | null => {
-  if (node instanceof HTMLElement) {
-    return elementToHast(node, contentType);
+  if (node.nodeType === node.TEXT_NODE) {
+    return node.nodeValue
+      ? { type: 'text', value: node.nodeValue }
+      : null;
+  } else if (node.nodeType === node.ELEMENT_NODE) {
+    return elementToHast(node as Element, contentType);
   }
+
   return null;
 };
 

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -11,6 +11,10 @@ const hastPropertyOfAttr = (attrib: Attr): HastProperties => {
       return {
         className: (attrib.nodeValue || '').split(' ').filter(Boolean),
       };
+    case 'for':
+      return {
+        htmlFor: attrib.nodeValue,
+      };
     default:
       return {
         [attrib.name]: attrib.nodeValue

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -18,7 +18,7 @@ const hastPropertyOfAttr = (attrib: Attr): HastProperties => {
   }
 }
 
-export const hastOfElement = (
+export const elementToHast = (
   element: Element,
   contentType: ContentType,
 ): HastNode => {
@@ -41,12 +41,22 @@ export const hastOfElement = (
       type: 'element',
       tagName: contentType === 'text/html' ? element.tagName.toLowerCase() : element.tagName,
       properties,
-      children: hastChildrenOfNode(element, contentType),
+      children: nodeChildrenToHastArray(element, contentType),
     });
   }
-}
+};
 
-export const hastChildrenOfNode = (
+export const nodeToHast = (
+  node: Node,
+  contentType: ContentType,
+): HastNode | null => {
+  if (node instanceof HTMLElement) {
+    return elementToHast(node, contentType);
+  }
+  return null;
+};
+
+export const nodeChildrenToHastArray = (
   node: Node,
   contentType: ContentType,
 ): HastNode[] => {
@@ -54,8 +64,10 @@ export const hastChildrenOfNode = (
   if (node.hasChildNodes()) {
     for (let i = 0; i < node.childNodes.length; i += 1) {
       const childNode = node.childNodes[i];
-      const hastNode = hastOfElement(childNode as Element, contentType);
-      hastNodes.push(hastNode);
+      const hastNode = nodeToHast(childNode, contentType);
+      if (hastNode) {
+        hastNodes.push(hastNode);
+      }
     }
   }
   return hastNodes;

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -5,22 +5,35 @@ import {
 } from './types';
 import { compressElementNode } from './util';
 
+// Hast/React compliant attribute converter
 const hastPropertyOfAttr = (attrib: Attr): HastProperties => {
-  switch (attrib.name) {
-    case 'class':
-      return {
-        className: (attrib.nodeValue || '').split(' ').filter(Boolean),
-      };
-    case 'for':
-      return {
-        htmlFor: attrib.nodeValue,
-      };
-    default:
-      return {
-        [attrib.name]: attrib.nodeValue
-      };
+  const { name, nodeValue } = attrib;
+
+  if (name === 'class') {
+    return {
+      className: (nodeValue || '').split(' ').filter(Boolean),
+    };
+  } else if (name === 'for') {
+    return {
+      htmlFor: nodeValue,
+    };
+  } else if (name.startsWith('data-') || name.startsWith('aria-')) {
+    // Just convert to lower case
+    return {
+      [name.toLowerCase()]: nodeValue,
+    };
+  } else if (name.indexOf('-') >= 0) {
+    // To camelCase
+    const camelCased = name.replace(/-([a-z])/g, g => g[1].toUpperCase());
+    return {
+      [camelCased]: nodeValue
+    };
+  } else {
+    return {
+      [name]: nodeValue
+    };
   }
-}
+};
 
 export const elementToHast = (
   element: Element,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './types';
 export * from './util';
 export * from './conversion';
+export * from './properties';
 export * from './config';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
 export * from './util';
 export * from './conversion';
+export * from './config';

--- a/src/properties.ts
+++ b/src/properties.ts
@@ -40,10 +40,10 @@ const hastPropertyToJs = (
   const info = findPropertyInfo(infoSpace, property);
   if (!info) return {};
 
-  if (info.commaSeparated) {
-    return { [property]: value.join(', ') };
-  } else if (info.spaceSeparated) {
+  if (info.spaceSeparated || info.commaOrSpaceSeparated) {
     return { [property]: value.join(' ') };
+  } else if (info.commaSeparated) {
+    return { [property]: value.join(', ') };
   }
 
   return { [property]: value };

--- a/src/properties.ts
+++ b/src/properties.ts
@@ -1,0 +1,122 @@
+import { HastProperties } from "./types";
+
+const info = require('property-information');
+
+export type InfoSpace = any;
+
+// See https://github.com/wooorm/property-information#readme
+interface PropertyInfo {
+  space: string;
+  attribute: string;
+  property: string;
+  boolean?: boolean;
+  booleanish?: boolean;
+  overloadedBoolean?: boolean;
+  number?: boolean;
+  spaceSeparated?: boolean;
+  commaSeparated?: boolean;
+  commaOrSpaceSeparated?: boolean;
+  mustUseProperty?: boolean;
+  defined?: boolean;
+}
+
+export const htmlSpace: InfoSpace = info.html;
+export const xmlSpace: InfoSpace = info.xml;
+
+const findPropertyInfo = (
+  infoSpace: InfoSpace,
+  propertyOrAttr: string
+): PropertyInfo | null => info.find(infoSpace, propertyOrAttr) || null;
+
+const hastPropertyToJs = (
+  infoSpace: InfoSpace,
+  property: string,
+  value: any,
+): { [property: string]: any } => {
+  if (property.startsWith('data-') && infoSpace === htmlSpace) {
+    return [property, value];
+  }
+
+  const info = findPropertyInfo(infoSpace, property);
+  if (!info) return {};
+
+  if (info.commaSeparated) {
+    return { [property]: value.join(', ') };
+  } else if (info.spaceSeparated) {
+    return { [property]: value.join(' ') };
+  }
+
+  return { [property]: value };
+};
+
+export const hastPropertyToMarkup = (
+  infoSpace: InfoSpace,
+  property: string,
+  value: any,
+): [string, string] | string | null => {
+  if (property.startsWith('data-') && infoSpace === htmlSpace) {
+    return [property, value];
+  }
+
+  const info = findPropertyInfo(infoSpace, property);
+  if (!info) return null;
+
+  const { attribute } = info;
+
+  if (info.boolean || info.overloadedBoolean) {
+    return value ? attribute : null;
+  }
+  if (info.spaceSeparated || info.commaOrSpaceSeparated)  {
+    return [attribute, typeof value === 'string' ? value : value.join(' ')];
+  }
+  if (info.commaSeparated) {
+    return [attribute, typeof value === 'string' ? value : value.join(', ')];
+  }
+
+  return [attribute, `${value}`];
+};
+
+export const markupAttributeToHastProperty = (
+  infoSpace: InfoSpace,
+  attribute: string,
+  value: any,
+): HastProperties => {
+  if (attribute.startsWith('data-') && infoSpace === htmlSpace) {
+    return { [attribute]: value };
+  }
+
+  const info = findPropertyInfo(infoSpace, attribute);
+  if (!info) return {};
+
+  const { property } = info;
+
+  if (info.boolean || info.overloadedBoolean) {
+    return { [property]: true, };
+  }
+  if (info.booleanish) {
+    return { [property]: value.toLowerCase().includes('false') ? false : true };
+  }
+  if (info.spaceSeparated) {
+    return { [property]: value.split(/[\s]+/), };
+  }
+  if (info.commaSeparated) {
+    return { [property]: value.split(/[,]/), };
+  }
+  if (info.commaOrSpaceSeparated) {
+    return { [property]: value.split(/[\s,]+/), };
+  }
+
+  return { [property]: value, };
+};
+
+export const hastPropertiesToJs = (
+  infoSpace: InfoSpace,
+  properties?: HastProperties
+): { [property: string]: any } | null => {
+  if (!properties) return null;
+
+  return Object.keys(properties).reduce((agg, property) => ({
+    ...agg,
+    ...hastPropertyToJs(infoSpace, property, properties[property]),
+  }), {});
+};

--- a/src/properties.ts
+++ b/src/properties.ts
@@ -100,7 +100,7 @@ export const markupAttributeToHastProperty = (
     return { [property]: value.split(/[\s]+/), };
   }
   if (info.commaSeparated) {
-    return { [property]: value.split(/[,]/), };
+    return { [property]: value.split(/[,]/).map((str: string) => str.trim()), };
   }
   if (info.commaOrSpaceSeparated) {
     return { [property]: value.split(/[\s,]+/), };

--- a/src/serialization.ts
+++ b/src/serialization.ts
@@ -1,5 +1,6 @@
 import { HastNode, HastElementNode, HastProperties } from "./types";
 import { SerializationConfig } from "./config";
+import { isText } from "./util";
 
 const encodeUtf8Text = (text: string): string =>
   text
@@ -60,11 +61,11 @@ export const hastNodeToUtf8Markup = (
   node: HastNode,
   config: SerializationConfig,
 ): string => {
-  if (node.type === 'text') {
+  if (isText(node)) {
     return encodeUtf8Text(node.value);
   }
 
-  if (node.tagName === 'fragment') {
+  if (config.isFragment(node)) {
     if (node.children) {
       return node.children.map(child => hastNodeToUtf8Markup(child, config)).join('');
     }

--- a/src/serialization.ts
+++ b/src/serialization.ts
@@ -24,7 +24,16 @@ const hastPropertiesToUtf8Attributes = (
       const serialized = config.serializeAttribute(tagName, name, properties[name]);
       if (!serialized) return attributes;
 
+      if (typeof serialized === 'string') {
+        return [...attributes, serialized];
+      }
+
       const [attributeName, value] = serialized;
+
+      if (value === 'true') {
+        return [...attributes, attributeName];
+      }
+
       return [...attributes, `${attributeName}="${encodeUtf8AttributeValue(value)}"`];
     }, [] as string[]);
 };

--- a/src/serialization.ts
+++ b/src/serialization.ts
@@ -32,5 +32,12 @@ export const hastNodeToUtf8Markup = (node: HastNode): string => {
     return encodeUtf8Text(node.value);
   }
 
+  if (node.tagName === 'fragment') {
+    if (node.children) {
+      return node.children.map(hastNodeToUtf8Markup).join('');
+    }
+    return '';
+  }
+
   return hastElementNodeToUtf8Markup(node);
 };

--- a/src/serialization.ts
+++ b/src/serialization.ts
@@ -31,10 +31,6 @@ const hastPropertiesToUtf8Attributes = (
 
       const [attributeName, value] = serialized;
 
-      if (value === 'true') {
-        return [...attributes, attributeName];
-      }
-
       return [...attributes, `${attributeName}="${encodeUtf8AttributeValue(value)}"`];
     }, [] as string[]);
 };

--- a/src/test/conversion.test.ts
+++ b/src/test/conversion.test.ts
@@ -1,11 +1,13 @@
 import { DOMParser } from 'xmldom';
-import { domNodeToHast } from '../conversion';
+
+import * as conversion from '../conversion';
 
 describe('conversion', () => {
   it('converts html document', () => {
     const doc = new DOMParser().parseFromString('<span>Some <STRONG>text</STRONG></span>', 'text/html');
-    const hast = domNodeToHast(doc, 'text/html');
-    expect(hast).toEqual({
+    const fragment = conversion.domNodeToHastFragment(doc, 'text/html');
+
+    expect(fragment).toEqual({
       type: 'element',
       tagName: 'fragment',
       children: [{

--- a/src/test/conversion.test.ts
+++ b/src/test/conversion.test.ts
@@ -1,13 +1,13 @@
 import { DOMParser } from 'xmldom';
-import { domElementToHastBody } from '../conversion';
+import { domElementToHastFragment } from '../conversion';
 
 describe('conversion', () => {
   it('converts html document', () => {
     const doc = new DOMParser().parseFromString('<span>Some <STRONG>text</STRONG></span>', 'text/html');
-    const hast = domElementToHastBody(doc, 'text/html');
+    const hast = domElementToHastFragment(doc, 'text/html');
     expect(hast).toEqual({
       type: 'element',
-      tagName: 'body',
+      tagName: 'fragment',
       children: [{
         type: 'element',
         tagName: 'span',

--- a/src/test/conversion.test.ts
+++ b/src/test/conversion.test.ts
@@ -3,7 +3,9 @@ import { DOMParser } from 'xmldom';
 import * as conversion from '../conversion';
 import * as config from '../config';
 
-const html5Config = config.html5DeserializationConfig();
+const htmlAttributeMap = config.compileAttributeMap(require('react-html-attributes'));
+
+const html5Config = config.html5DeserializationConfig(htmlAttributeMap);
 
 const HTML_SPAN_DOC = new DOMParser().parseFromString(
   '<span>Some <STRONG>text</STRONG></span>',

--- a/src/test/conversion.test.ts
+++ b/src/test/conversion.test.ts
@@ -1,6 +1,9 @@
 import { DOMParser } from 'xmldom';
 
 import * as conversion from '../conversion';
+import * as config from '../config';
+
+const html5Config = config.html5DeserializationConfig();
 
 const HTML_SPAN_DOC = new DOMParser().parseFromString(
   '<span>Some <STRONG>text</STRONG></span>',
@@ -14,7 +17,7 @@ const HTML_UNENCLOSED_DOC = new DOMParser().parseFromString(
 
 describe('conversion', () => {
   it('converts full html document to fragment', () => {
-    const fragment = conversion.domNodeToHastFragment(HTML_SPAN_DOC, 'text/html');
+    const fragment = conversion.domNodeToHastFragment(HTML_SPAN_DOC, html5Config);
 
     expect(fragment).toEqual({
       type: 'element',
@@ -38,7 +41,7 @@ describe('conversion', () => {
   });
 
   it('does not contain unenclosed text elements', () => {
-    const fragment = conversion.domNodeToHastFragment(HTML_UNENCLOSED_DOC, 'text/html');
+    const fragment = conversion.domNodeToHastFragment(HTML_UNENCLOSED_DOC, html5Config);
 
     expect(fragment).toEqual({
       type: 'element',

--- a/src/test/conversion.test.ts
+++ b/src/test/conversion.test.ts
@@ -2,10 +2,19 @@ import { DOMParser } from 'xmldom';
 
 import * as conversion from '../conversion';
 
+const HTML_SPAN_DOC = new DOMParser().parseFromString(
+  '<span>Some <STRONG>text</STRONG></span>',
+  'text/html'
+);
+
+const HTML_UNENCLOSED_DOC = new DOMParser().parseFromString(
+  'Some <STRONG>text</STRONG>',
+  'text/html'
+);
+
 describe('conversion', () => {
-  it('converts html document', () => {
-    const doc = new DOMParser().parseFromString('<span>Some <STRONG>text</STRONG></span>', 'text/html');
-    const fragment = conversion.domNodeToHastFragment(doc, 'text/html');
+  it('converts full html document to fragment', () => {
+    const fragment = conversion.domNodeToHastFragment(HTML_SPAN_DOC, 'text/html');
 
     expect(fragment).toEqual({
       type: 'element',
@@ -25,6 +34,23 @@ describe('conversion', () => {
           }],
         }],
       }]
+    });
+  });
+
+  it('does not contain unenclosed text elements', () => {
+    const fragment = conversion.domNodeToHastFragment(HTML_UNENCLOSED_DOC, 'text/html');
+
+    expect(fragment).toEqual({
+      type: 'element',
+      tagName: 'fragment',
+      children: [{
+        type: 'element',
+        tagName: 'strong',
+        children: [{
+          type: 'text',
+          value: 'text',
+        }],
+      }],
     });
   });
 });

--- a/src/test/conversion.test.ts
+++ b/src/test/conversion.test.ts
@@ -1,10 +1,10 @@
 import { DOMParser } from 'xmldom';
-import { domElementToHastFragment } from '../conversion';
+import { domNodeToHast } from '../conversion';
 
 describe('conversion', () => {
   it('converts html document', () => {
     const doc = new DOMParser().parseFromString('<span>Some <STRONG>text</STRONG></span>', 'text/html');
-    const hast = domElementToHastFragment(doc, 'text/html');
+    const hast = domNodeToHast(doc, 'text/html');
     expect(hast).toEqual({
       type: 'element',
       tagName: 'fragment',

--- a/src/test/conversion.test.ts
+++ b/src/test/conversion.test.ts
@@ -3,9 +3,7 @@ import { DOMParser } from 'xmldom';
 import * as conversion from '../conversion';
 import * as config from '../config';
 
-const htmlAttributeMap = config.compileAttributeMap(require('react-html-attributes'));
-
-const html5Config = config.html5DeserializationConfig(htmlAttributeMap);
+const html5Config = config.html5DeserializationConfig();
 
 const HTML_SPAN_DOC = new DOMParser().parseFromString(
   '<span>Some <STRONG>text</STRONG></span>',

--- a/src/test/dom.test.ts
+++ b/src/test/dom.test.ts
@@ -1,13 +1,18 @@
 import { DOMParser } from 'xmldom';
 
-import { elementToHast } from '../dom';
+import * as dom from '../dom';
+
+const XML_DOC = new DOMParser().parseFromString('<Yo />', 'text/xml');
 
 describe('dom', () => {
+  it('does not convert document to hast', () => {
+    expect(dom.nodeToHast(XML_DOC, 'application/xml')).toEqual(null);
+  });
+
   it('converts xml document to hast, retains tagName casing', () => {
-    const doc = new DOMParser().parseFromString('<Yo />', 'text/xml');
-    const hast = elementToHast(
-      doc.childNodes[0] as Element,
-      'application/xml'
+    const hast = dom.nodeToHast(
+      XML_DOC.childNodes[0],
+      'application/xml',
     );
     expect(hast).toEqual({
       type: 'element',

--- a/src/test/dom.test.ts
+++ b/src/test/dom.test.ts
@@ -1,10 +1,11 @@
 import { DOMParser } from 'xmldom';
-import { hastOfElement } from '../dom';
+
+import { elementToHast } from '../dom';
 
 describe('dom', () => {
-  it('converts xml document to hast, retains tagname casing', () => {
+  it('converts xml document to hast, retains tagName casing', () => {
     const doc = new DOMParser().parseFromString('<Yo />', 'text/xml');
-    const hast = hastOfElement(
+    const hast = elementToHast(
       doc.childNodes[0] as Element,
       'application/xml'
     );

--- a/src/test/dom.test.ts
+++ b/src/test/dom.test.ts
@@ -28,6 +28,21 @@ const FORM_DOC = new DOMParser().parseFromString(
   'text/html',
 );
 
+const BOOL_ATTR_DOC = new DOMParser().parseFromString(
+  '<input autocomplete/>',
+  'text/html',
+);
+
+const TEXT_ENTITIES_DOC = new DOMParser().parseFromString(
+  'Bl&aring;b&aelig;rsyltet&oslash;y',
+  'text/html',
+);
+
+const TEXT_UTF8_DOC = new DOMParser().parseFromString(
+  'Blåbærsyltetøy',
+  'text/html',
+);
+
 describe('dom', () => {
   it('does not convert document to hast', () => {
     expect(dom.nodeToHast(XML_DOC, xmlConfig)).toEqual(null);
@@ -83,6 +98,30 @@ describe('dom', () => {
           minLength: '2',
         },
       }],
+    });
+  });
+
+  it('parses "boolean" attributes as string', () => {
+    expect(dom.nodeToHast(BOOL_ATTR_DOC.childNodes[0], html5Config)).toEqual({
+      type: 'element',
+      tagName: 'input',
+      properties: {
+        autoComplete: 'autocomplete',
+      },
+    });
+  });
+
+  it('keeps character entities', () => {
+    expect(dom.nodeToHast(TEXT_ENTITIES_DOC.childNodes[0], html5Config)).toEqual({
+      type: 'text',
+      value: 'Bl&aring;b&aelig;rsyltet&oslash;y',
+    });
+  });
+
+  it('accepts utf-8', () => {
+    expect(dom.nodeToHast(TEXT_UTF8_DOC.childNodes[0], html5Config)).toEqual({
+      type: 'text',
+      value: 'Blåbærsyltetøy',
     });
   });
 });

--- a/src/test/dom.test.ts
+++ b/src/test/dom.test.ts
@@ -3,8 +3,10 @@ import { DOMParser } from 'xmldom';
 import * as dom from '../dom';
 import * as config from '../config';
 
+const htmlAttributeMap = config.compileAttributeMap(require('react-html-attributes'));
+
 const xmlConfig = config.xmlDeserializationConfig();
-const html5Config = config.html5DeserializationConfig();
+const html5Config = config.html5DeserializationConfig(htmlAttributeMap);
 
 const XML_DOC = new DOMParser().parseFromString(
   '<Yo />',
@@ -67,7 +69,7 @@ describe('dom', () => {
     });
   });
 
-  it('does something with attribute', () => {
+  it('transforms html attribute name to react-compliant camelCase naming', () => {
     expect(dom.nodeToHast(INPUT_DOC.childNodes[0], html5Config)).toEqual({
       type: 'element',
       tagName: 'input',

--- a/src/test/dom.test.ts
+++ b/src/test/dom.test.ts
@@ -1,6 +1,10 @@
 import { DOMParser } from 'xmldom';
 
 import * as dom from '../dom';
+import * as config from '../config';
+
+const xmlConfig = config.xmlDeserializationConfig();
+const html5Config = config.html5DeserializationConfig();
 
 const XML_DOC = new DOMParser().parseFromString(
   '<Yo />',
@@ -24,18 +28,18 @@ const INPUT_DOC = new DOMParser().parseFromString(
 
 describe('dom', () => {
   it('does not convert document to hast', () => {
-    expect(dom.nodeToHast(XML_DOC, 'application/xml')).toEqual(null);
+    expect(dom.nodeToHast(XML_DOC, xmlConfig)).toEqual(null);
   });
 
   it('converts xml document to hast, retains tagName casing', () => {
-    expect(dom.nodeToHast(XML_DOC.childNodes[0], 'application/xml')).toEqual({
+    expect(dom.nodeToHast(XML_DOC.childNodes[0], xmlConfig)).toEqual({
       type: 'element',
       tagName: 'Yo',
     });
   });
 
   it('skips comments', () => {
-    expect(dom.nodeToHast(COMMENT_DOC.childNodes[0], 'text/html')).toEqual({
+    expect(dom.nodeToHast(COMMENT_DOC.childNodes[0], html5Config)).toEqual({
       type: 'element',
       tagName: 'span',
       children: [{
@@ -49,7 +53,7 @@ describe('dom', () => {
   });
 
   it('encodes special names', () => {
-    expect(dom.nodeToHast(LABEL_DOC.childNodes[0], 'text/html')).toEqual({
+    expect(dom.nodeToHast(LABEL_DOC.childNodes[0], html5Config)).toEqual({
       type: 'element',
       tagName: 'label',
       properties: {
@@ -64,7 +68,7 @@ describe('dom', () => {
   });
 
   it('does something with attribute', () => {
-    expect(dom.nodeToHast(INPUT_DOC.childNodes[0], 'text/html')).toEqual({
+    expect(dom.nodeToHast(INPUT_DOC.childNodes[0], html5Config)).toEqual({
       type: 'element',
       tagName: 'input',
       properties: {

--- a/src/test/dom.test.ts
+++ b/src/test/dom.test.ts
@@ -130,7 +130,7 @@ describe('dom', () => {
     });
   });
 
-  it('retains data attribute', () => {
+  it('retains data attribute untranslated', () => {
     expect(dom.nodeToHast(DATA_DOC.childNodes[0], html5Config)).toEqual({
       type: 'element',
       tagName: 'div',

--- a/src/test/dom.test.ts
+++ b/src/test/dom.test.ts
@@ -17,6 +17,11 @@ const LABEL_DOC = new DOMParser().parseFromString(
   'text/html',
 );
 
+const INPUT_DOC = new DOMParser().parseFromString(
+  '<input minlength="2" />',
+  'text/html',
+);
+
 describe('dom', () => {
   it('does not convert document to hast', () => {
     expect(dom.nodeToHast(XML_DOC, 'application/xml')).toEqual(null);
@@ -55,6 +60,16 @@ describe('dom', () => {
         type: 'text',
         value: 'baz',
       }],
+    });
+  });
+
+  it('does something with attribute', () => {
+    expect(dom.nodeToHast(INPUT_DOC.childNodes[0], 'text/html')).toEqual({
+      type: 'element',
+      tagName: 'input',
+      properties: {
+        minLength: '2',
+      },
     });
   });
 });

--- a/src/test/dom.test.ts
+++ b/src/test/dom.test.ts
@@ -27,7 +27,7 @@ const FORM_DOC = new DOMParser().parseFromString(
 );
 
 const BOOL_ATTR_DOC = new DOMParser().parseFromString(
-  '<input autocomplete="on"/>',
+  '<button disabled="true"/>',
   'text/html',
 );
 
@@ -109,9 +109,9 @@ describe('dom', () => {
   it('parses "boolean" attributes as string', () => {
     expect(dom.nodeToHast(BOOL_ATTR_DOC.childNodes[0], html5Config)).toEqual({
       type: 'element',
-      tagName: 'input',
+      tagName: 'button',
       properties: {
-        autoComplete: ['on'],
+        disabled: true,
       },
     });
   });

--- a/src/test/dom.test.ts
+++ b/src/test/dom.test.ts
@@ -3,10 +3,8 @@ import { DOMParser } from 'xmldom';
 import * as dom from '../dom';
 import * as config from '../config';
 
-const htmlAttributeMap = config.compileAttributeMap(require('react-html-attributes'));
-
 const xmlConfig = config.xmlDeserializationConfig();
-const html5Config = config.html5DeserializationConfig(htmlAttributeMap);
+const html5Config = config.html5DeserializationConfig();
 
 const XML_DOC = new DOMParser().parseFromString(
   '<Yo />',
@@ -29,7 +27,7 @@ const FORM_DOC = new DOMParser().parseFromString(
 );
 
 const BOOL_ATTR_DOC = new DOMParser().parseFromString(
-  '<input autocomplete/>',
+  '<input autocomplete="on"/>',
   'text/html',
 );
 
@@ -40,6 +38,11 @@ const TEXT_ENTITIES_DOC = new DOMParser().parseFromString(
 
 const TEXT_UTF8_DOC = new DOMParser().parseFromString(
   'Blåbærsyltetøy',
+  'text/html',
+);
+
+const DATA_DOC = new DOMParser().parseFromString(
+  '<div data-foo="bar" />',
   'text/html',
 );
 
@@ -75,7 +78,7 @@ describe('dom', () => {
       tagName: 'label',
       properties: {
         className: ['foo'],
-        htmlFor: 'bar',
+        htmlFor: ['bar'],
       },
       children: [{
         type: 'text',
@@ -89,7 +92,9 @@ describe('dom', () => {
       type: 'element',
       tagName: 'form',
       properties: {
+        acceptCharset: ['foo'],
         method: 'POST',
+        foo: 'bar',
       },
       children: [{
         type: 'element',
@@ -106,7 +111,7 @@ describe('dom', () => {
       type: 'element',
       tagName: 'input',
       properties: {
-        autoComplete: 'autocomplete',
+        autoComplete: ['on'],
       },
     });
   });
@@ -124,4 +129,14 @@ describe('dom', () => {
       value: 'Blåbærsyltetøy',
     });
   });
+
+  it('retains data attribute', () => {
+    expect(dom.nodeToHast(DATA_DOC.childNodes[0], html5Config)).toEqual({
+      type: 'element',
+      tagName: 'div',
+      properties: {
+        'data-foo': 'bar',
+      },
+    })
+  })
 });

--- a/src/test/dom.test.ts
+++ b/src/test/dom.test.ts
@@ -46,6 +46,11 @@ const DATA_DOC = new DOMParser().parseFromString(
   'text/html',
 );
 
+const IMG_DOC = new DOMParser().parseFromString(
+  '<img srcset="a, b , c"/>',
+  'text/html'
+);
+
 describe('dom', () => {
   it('does not convert document to hast', () => {
     expect(dom.nodeToHast(XML_DOC, xmlConfig)).toEqual(null);
@@ -137,6 +142,16 @@ describe('dom', () => {
       properties: {
         'data-foo': 'bar',
       },
-    })
+    });
+  });
+
+  it('parses "list" attributes', () => {
+    expect(dom.nodeToHast(IMG_DOC.childNodes[0], html5Config)).toEqual({
+      type: 'element',
+      tagName: 'img',
+      properties: {
+        srcSet: ['a', 'b', 'c'],
+      },
+    });
   })
 });

--- a/src/test/dom.test.ts
+++ b/src/test/dom.test.ts
@@ -23,8 +23,8 @@ const LABEL_DOC = new DOMParser().parseFromString(
   'text/html',
 );
 
-const INPUT_DOC = new DOMParser().parseFromString(
-  '<input minlength="2" />',
+const FORM_DOC = new DOMParser().parseFromString(
+  '<form accept-charset="foo" method="POST" foo="bar"><input minlength="2" /></form>',
   'text/html',
 );
 
@@ -70,12 +70,19 @@ describe('dom', () => {
   });
 
   it('transforms html attribute name to react-compliant camelCase naming', () => {
-    expect(dom.nodeToHast(INPUT_DOC.childNodes[0], html5Config)).toEqual({
+    expect(dom.nodeToHast(FORM_DOC.childNodes[0], html5Config)).toEqual({
       type: 'element',
-      tagName: 'input',
+      tagName: 'form',
       properties: {
-        minLength: '2',
+        method: 'POST',
       },
+      children: [{
+        type: 'element',
+        tagName: 'input',
+        properties: {
+          minLength: '2',
+        },
+      }],
     });
   });
 });

--- a/src/test/serialization.test.ts
+++ b/src/test/serialization.test.ts
@@ -1,11 +1,15 @@
 import { hastNodeToUtf8Markup } from "../serialization";
+import * as config from '../config';
+
+const htmlAttributeMap = config.compileAttributeMap(require('react-html-attributes'));
+const html5Config = config.html5SerializationConfig(htmlAttributeMap);
 
 describe('serialization', () => {
   it('serializes text node', () => {
     const html = hastNodeToUtf8Markup({
       type: 'text',
       value: '<html tags & stuff>',
-    });
+    }, html5Config);
     expect(html).toEqual(
       '&lt;html tags &amp; stuff&gt;'
     );
@@ -18,7 +22,7 @@ describe('serialization', () => {
       properties: {
         src: 'http://"image"'
       }
-    });
+    }, html5Config);
     expect(html).toEqual(
       '<img src="http://&quot;image&quot;"/>'
     );
@@ -29,7 +33,7 @@ describe('serialization', () => {
       type: 'element',
       tagName: 'p',
       properties: {
-        class: 'yo',
+        className: ['foo', 'bar'],
       },
       children: [{
         type: 'text',
@@ -45,9 +49,9 @@ describe('serialization', () => {
           value: 'yo',
         }]
       }],
-    });
+    }, html5Config);
     expect(html).toEqual(
-      '<p class="yo">tekst<br/><strong>yo</strong></p>'
+      '<p class="foo bar">tekst<br/><strong>yo</strong></p>'
     );
   });
 });

--- a/src/test/serialization.test.ts
+++ b/src/test/serialization.test.ts
@@ -72,4 +72,23 @@ describe('serialization', () => {
       '<p class="foo bar">tekst<br/><div data-foo="bar"/><input autocomplete/><img srcset="yo"/><strong>yo</strong></p>'
     );
   });
+
+  it('serializes fragments', () => {
+    const html = hastNodeToUtf8Markup({
+      type: 'element',
+      tagName: 'fragment',
+      children: [{
+        type: 'text',
+        value: 'foo',
+      }, {
+        type: 'element',
+        tagName: 'fragment',
+        children: [{
+          type: 'text',
+          value: 'bar',
+        }]
+      }]
+    }, html5Config);
+    expect(html).toEqual('foobar');
+  });
 });

--- a/src/test/serialization.test.ts
+++ b/src/test/serialization.test.ts
@@ -43,6 +43,24 @@ describe('serialization', () => {
         tagName: 'br',
       }, {
         type: 'element',
+        tagName: 'div',
+        properties: {
+          'data-foo': 'bar',
+        },
+      }, {
+        type: 'element',
+        tagName: 'input',
+        properties: {
+          autoComplete: true,
+        },
+      }, {
+        type: 'element',
+        tagName: 'img',
+        properties: {
+          srcSet: 'yo',
+        }
+      }, {
+        type: 'element',
         tagName: 'strong',
         children: [{
           type: 'text',
@@ -51,7 +69,7 @@ describe('serialization', () => {
       }],
     }, html5Config);
     expect(html).toEqual(
-      '<p class="foo bar">tekst<br/><strong>yo</strong></p>'
+      '<p class="foo bar">tekst<br/><div data-foo="bar"/><input autocomplete/><img srcset="yo"/><strong>yo</strong></p>'
     );
   });
 });

--- a/src/test/serialization.test.ts
+++ b/src/test/serialization.test.ts
@@ -1,8 +1,7 @@
 import { hastNodeToUtf8Markup } from "../serialization";
 import * as config from '../config';
 
-const htmlAttributeMap = config.compileAttributeMap(require('react-html-attributes'));
-const html5Config = config.html5SerializationConfig(htmlAttributeMap);
+const html5Config = config.html5SerializationConfig();
 
 describe('serialization', () => {
   it('serializes text node', () => {
@@ -51,7 +50,7 @@ describe('serialization', () => {
         type: 'element',
         tagName: 'input',
         properties: {
-          autoComplete: true,
+          autoComplete: 'on',
         },
       }, {
         type: 'element',
@@ -69,7 +68,7 @@ describe('serialization', () => {
       }],
     }, html5Config);
     expect(html).toEqual(
-      '<p class="foo bar">tekst<br/><div data-foo="bar"/><input autocomplete/><img srcset="yo"/><strong>yo</strong></p>'
+      '<p class="foo bar">tekst<br/><div data-foo="bar"/><input autocomplete="on"/><img srcset="yo"/><strong>yo</strong></p>'
     );
   });
 

--- a/src/test/serialization.test.ts
+++ b/src/test/serialization.test.ts
@@ -56,8 +56,20 @@ describe('serialization', () => {
         type: 'element',
         tagName: 'img',
         properties: {
-          srcSet: 'yo',
+          srcSet: ['foo', 'bar'],
         }
+      }, {
+        type: 'element',
+        tagName: 'button',
+        properties: {
+          disabled: true,
+        },
+      }, {
+        type: 'element',
+        tagName: 'button',
+        properties: {
+          disabled: false,
+        },
       }, {
         type: 'element',
         tagName: 'strong',
@@ -68,7 +80,7 @@ describe('serialization', () => {
       }],
     }, html5Config);
     expect(html).toEqual(
-      '<p class="foo bar">tekst<br/><div data-foo="bar"/><input autocomplete="on"/><img srcset="yo"/><strong>yo</strong></p>'
+      '<p class="foo bar">tekst<br/><div data-foo="bar"/><input autocomplete="on"/><img srcset="foo, bar"/><button disabled/><button/><strong>yo</strong></p>'
     );
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,3 @@
-export type ContentType = 'text/html' | 'application/xml';
-
 export interface HastProperties {
   className?: string[],
   [key: string]: any,

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,9 +17,16 @@ export interface HastElementNode {
   children?: HastNode[];
 }
 
-export interface HastBodyNode {
+/**
+ * The "fragment" element is a special construct and is used
+ * when several elements are being represented in order as an array,
+ * without any specified wrapper node. In other words, the fragment element
+ * should always be removed from a DOM tree, its children merged into the fragment's
+ * siblings, if any.
+ */
+export interface HastFragmentNode {
   type: 'element';
-  tagName: 'body';
+  tagName: 'fragment';
   children?: HastNode[];
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,7 +2,7 @@ import {
   HastProperties,
   HastNode,
   HastElementNode,
-  HastBodyNode,
+  HastFragmentNode,
 } from './types';
 
 export const stripHastDebug = (node: HastNode): HastNode => {
@@ -39,9 +39,10 @@ export const compressProperties = (properties?: HastProperties): { properties?: 
   };
 }
 
-export const compressBodyNode = (node: HastBodyNode): HastBodyNode => {
+export const compressFragmentNode = (node: HastFragmentNode): HastFragmentNode => {
   return {
-    ...node,
+    type: 'element',
+    tagName: 'fragment',
     ...compressChildren(node.children),
   };
 };
@@ -63,7 +64,6 @@ export const compressNode = (node: HastNode): HastNode => {
   return compressElementNode(node);
 };
 
-
 /** Remove all unnecessary properties from hast document */
 export const compressDocument = (node: HastNode): HastNode => {
   if (node.type === 'text') {
@@ -74,13 +74,5 @@ export const compressDocument = (node: HastNode): HastNode => {
     ...node,
     ...compressProperties(node.properties),
     ...node.children && compressChildren(node.children.map(compressDocument)),
-  };
-};
-
-export const compressDocumentBody = (node: HastBodyNode): HastBodyNode => {
-  return {
-    type: 'element',
-    tagName: 'body',
-    ...compressChildren(node.children),
   };
 };

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,12 +1,25 @@
 import {
   HastProperties,
   HastNode,
+  HastTextNode,
   HastElementNode,
   HastFragmentNode,
 } from './types';
 
+export const isText = (node: HastNode): node is HastTextNode =>
+  node.type === 'text';
+
+export const isElement = (node: HastNode): node is HastElementNode =>
+  node.type === 'element';
+
+export const hasClass = (node: HastElementNode, className: string): boolean =>
+  node.properties
+  && node.properties.className
+  && node.properties.className.some(name => name === className)
+  || false;
+
 export const stripHastDebug = (node: HastNode): HastNode => {
-  if (node.type === 'text') {
+  if (isText(node)) {
     return node;
   }
 
@@ -57,18 +70,14 @@ export const compressElementNode = (node: HastElementNode): HastElementNode => {
 };
 
 export const compressNode = (node: HastNode): HastNode => {
-  if (node.type === 'text') {
-    return node;
-  }
+  if (isText(node)) return node;
 
   return compressElementNode(node);
 };
 
 /** Remove all unnecessary properties from hast document */
 export const compressDocument = (node: HastNode): HastNode => {
-  if (node.type === 'text') {
-    return node;
-  }
+  if (isText(node)) return node;
 
   return {
     ...node,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1292,6 +1292,11 @@ hosted-git-info@^2.1.4:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
   integrity sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==
 
+html-element-attributes@^1.0.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/html-element-attributes/-/html-element-attributes-1.3.1.tgz#9fa6a2e37e6b61790a303e87ddbbb9746e8c035f"
+  integrity sha512-UrRKgp5sQmRnDy4TEwAUsu14XBUlzKB8U3hjIYDjcZ3Hbp86Jtftzxfgrv6E/ii/h78tsaZwAnAE8HwnHr0dPA==
+
 html-encoding-sniffer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
@@ -2652,6 +2657,13 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+react-html-attributes@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/react-html-attributes/-/react-html-attributes-1.4.3.tgz#8c36c35fce6b750938d286af428ed1da7625186e"
+  integrity sha1-jDbDX85rdQk40oavQo7R2nYlGG4=
+  dependencies:
+    html-element-attributes "^1.0.0"
 
 react-is@^16.8.4:
   version "16.8.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1292,11 +1292,6 @@ hosted-git-info@^2.1.4:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
   integrity sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==
 
-html-element-attributes@^1.0.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/html-element-attributes/-/html-element-attributes-1.3.1.tgz#9fa6a2e37e6b61790a303e87ddbbb9746e8c035f"
-  integrity sha512-UrRKgp5sQmRnDy4TEwAUsu14XBUlzKB8U3hjIYDjcZ3Hbp86Jtftzxfgrv6E/ii/h78tsaZwAnAE8HwnHr0dPA==
-
 html-encoding-sniffer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
@@ -2630,6 +2625,13 @@ prompts@^2.0.1:
     kleur "^3.0.2"
     sisteransi "^1.0.0"
 
+property-information@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/property-information/-/property-information-5.0.1.tgz#c3b09f4f5750b1634c0b24205adbf78f18bdf94f"
+  integrity sha512-nAtBDVeSwFM3Ot/YxT7s4NqZmqXI7lLzf46BThvotEtYf2uk2yH0ACYuWQkJ7gxKs49PPtKVY0UlDGkyN9aJlw==
+  dependencies:
+    xtend "^4.0.1"
+
 psl@^1.1.24, psl@^1.1.28:
   version "1.1.31"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.31.tgz#e9aa86d0101b5b105cbe93ac6b784cd547276184"
@@ -2657,13 +2659,6 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
-
-react-html-attributes@^1.4.3:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/react-html-attributes/-/react-html-attributes-1.4.3.tgz#8c36c35fce6b750938d286af428ed1da7625186e"
-  integrity sha1-jDbDX85rdQk40oavQo7R2nYlGG4=
-  dependencies:
-    html-element-attributes "^1.0.0"
 
 react-is@^16.8.4:
   version "16.8.6"
@@ -3476,6 +3471,11 @@ xmldom@^0.1.27:
   version "0.1.27"
   resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.27.tgz#d501f97b3bdb403af8ef9ecc20573187aadac0e9"
   integrity sha1-1QH5ezvbQDr4757MIFcxh6rawOk=
+
+xtend@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
+  integrity sha1-pcbVMr5lbiPbgg77lDofBJmNY68=
 
 "y18n@^3.2.1 || ^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
Change name of the typical root node from "body" to "fragment", in alignment with React's naming of the element that's skipped in the DOM.

Improved conversions.